### PR TITLE
Abstract API mocking into a reusable loadPage helper

### DIFF
--- a/src/web/ts/tests/e2e/conversion.spec.ts
+++ b/src/web/ts/tests/e2e/conversion.spec.ts
@@ -1,23 +1,8 @@
 import { test, expect } from "@playwright/test";
-import { setupCurrencies, takeScreenshot, fillAndConvert } from "../helpers/helpers";
+import { setupCurrencies, takeScreenshot, fillAndConvert, loadPage } from "../helpers/helpers";
 
 test.beforeEach(async ({ page }) => {
-  await page.route('https://api.exchangeratesapi.io/v1/latest**', async route => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({
-        success: true,
-        base: 'EUR',
-        rates: {
-          USD: 1.1,
-          EUR: 1.0,
-          GBP: 0.85,
-          CAD: 1.60
-        }
-      }),
-    });
-  });
+  await loadPage(page);
 });
 
 

--- a/src/web/ts/tests/e2e/conversion.spec.ts
+++ b/src/web/ts/tests/e2e/conversion.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "@playwright/test";
 import { setupCurrencies, takeScreenshot, fillAndConvert, loadPage } from "../helpers/helpers";
 
 test.beforeEach(async ({ page }) => {
-  await loadPage(page);
+  await loadPage({ page: page });
 });
 
 

--- a/src/web/ts/tests/helpers/helpers.ts
+++ b/src/web/ts/tests/helpers/helpers.ts
@@ -27,7 +27,7 @@ export const fillAndConvert = async (
   return page.inputValue(outputId);
 }
 
-export const loadPage = async (page: Page) => {
+export const loadPage = async ({ page }: { page: Page })  => {
   await page.route('https://api.exchangeratesapi.io/v1/latest**', async route => {
     await route.fulfill({
       status: 200,

--- a/src/web/ts/tests/helpers/helpers.ts
+++ b/src/web/ts/tests/helpers/helpers.ts
@@ -6,7 +6,6 @@ export const setupCurrencies = async (
   base = 'EUR',
   desired = 'USD'
 ) => {
-  await page.goto('http://localhost:5174/');
   await page.selectOption('#baseCurrency', base);
   await page.selectOption('#desiredCurrency', desired);
 }
@@ -26,4 +25,24 @@ export const fillAndConvert = async (
   await page.fill(inputId, amount);
   await takeScreenshot(page, `after_${screenshotPrefix}`);
   return page.inputValue(outputId);
+}
+
+export const loadPage = async (page: Page) => {
+  await page.route('https://api.exchangeratesapi.io/v1/latest**', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        base: 'EUR',
+        rates: {
+          USD: 1.1,
+          EUR: 1.0,
+          GBP: 0.85,
+          CAD: 1.60
+        }
+      }),
+    });
+  });
+  await page.goto('http://localhost:5174/');
 }


### PR DESCRIPTION
closes #76 

I created a new helper function called loadPage that handles both navigating to the page and intercepting the API call with mock data. The beforeEach block  now calls loadPage(page) directly. 