### PR TITLE
Create env file + update readme.md (WEB and API)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -97,22 +97,6 @@ apiKey: import.meta.env.VITE_EXCHANGE_RATES_API_KEY
 
 ### 4. Server-Side Configuration (Express / Firebase Functions)
 
-The Express API initializes `dotenv` at its entry point, pointing back four levels to load the workspace root `.env` file:
-
-```bash
-// src/api/routes.ts
-import dotenv from 'dotenv';
-import path from 'path';
-import { fileURLToPath } from 'url';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-// Resolve path to root /.env from build directory
-const envPath = path.resolve(__dirname, '../../../../.env');
-dotenv.config({ path: envPath });
-```
-
 Accessing in Backend TypeScript Code:
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,3 +53,49 @@ make -C src/web install
 ### API Backend (`src/api`)
 ```bash
 make -C src/api install
+```
+---
+
+## Environment Setup
+
+This project uses environment-based configuration to manage secrets securely across the frontend web client and backend services.
+
+### 1. Configuration Overview
+
+| Layer | File Path | Required Variable Prefix | Runtime Syntax |
+| :--- | :--- | :--- | :--- |
+| **Web Frontend (Vite)** | `/.env` (Workspace Root) | `VITE_` | `import.meta.env.VITE_...` |
+| **API Backend (Express)** | `/src/api/.env` | None | `process.env....` |
+
+> **Security Note:** `.env` files contain sensitive API credentials and **must never be committed to Git**. Ensure both `.env` and `src/api/.env` are listed in your `.gitignore`.
+
+### 2. Client-Side Configuration (/.env)
+
+Create a .env file in the project root directory: 
+
+```bash
+# Workspace Root /.env
+VITE_EXCHANGE_RATES_API_KEY=your_actual_api_key
+```
+
+Because the frontend project resides in `src/web/`, Vite relies on `envDir` inside `src/web/vite.config.ts` to locate the workspace root `.env` file:
+
+```bash
+// src/web/vite.config.ts
+import { defineConfig } from 'vite';
+import path from 'path';
+
+export default defineConfig({
+  envDir: path.resolve(__dirname, '../../'),
+  ...
+});
+```
+
+Accessing in Frontend TypeScript Code:
+
+```bash
+# /src/api/.env
+const apiKey = import.meta.env.VITE_EXCHANGE_RATES_API_KEY;
+```
+
+3. Server-Side Configuration (/src/api/.env)

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,25 +49,31 @@ make -C src/ install
 ```
 ## Environment Setup
 
-This project uses environment-based configuration to manage secrets securely across the frontend web client and backend services.
+This project uses a single, centralized environment file at the workspace root to manage configuration and secrets across both the frontend web client and backend Express services.
 
 ### 1. Configuration Overview
 
-| Layer | File Path | Required Variable Prefix | Runtime Syntax |
+| Layer | File Path | Variable Prefix/Name | Runtime Syntax |
 | :--- | :--- | :--- | :--- |
-| **Web Frontend (Vite)** | `/.env` (Workspace Root) | `VITE_` | `import.meta.env.VITE_...` |
-| **API Backend (Express)** | `/src/api/.env` | None | `process.env....` |
+| **Web Frontend (Vite)** | `/.env` (Workspace Root) | `VITE_EXCHANGE_RATES_API_KEY` | `import.meta.env.VITE_...` |
+| **API Backend (Express)** | `/.env` (Workspace Root) | `EXCHANGE_RATES_API_KEY` | `process.env.EXCHANGE_RATES_API_KEY` |
 
-> **Security Note:** `.env` files contain sensitive API credentials and **must never be committed to Git**. Ensure both `.env` and `src/api/.env` are listed in your `.gitignore`.
+> **Security Note:** `.env` files contain sensitive API credentials and **must never be committed to Git**. Ensure `.env` is listed in your root `.gitignore`.
 
-### 2. Client-Side Configuration (/.env)
+### 2. Workspace Root Configuration (/.env)
 
-Create a .env file in the project root directory: 
+Create a single .env file in the project root directory (/convertor/.env):
 
 ```bash
 # Workspace Root /.env
+
+# Frontend Key (Vite)
 VITE_EXCHANGE_RATES_API_KEY=your_actual_api_key
+
+# Backend Key (Express / Firebase Functions)
+EXCHANGE_RATES_API_KEY=your_actual_api_key
 ```
+### 3. Client-Side Configuration (Vite)
 
 Because the frontend project resides in `src/web/`, Vite relies on `envDir` inside `src/web/vite.config.ts` to locate the workspace root `.env` file:
 
@@ -85,8 +91,31 @@ export default defineConfig({
 Accessing in Frontend TypeScript Code:
 
 ```bash
-# /src/api/.env
-const apiKey = import.meta.env.VITE_EXCHANGE_RATES_API_KEY;
+# /src/web/ts/constants.ts
+apiKey: import.meta.env.VITE_EXCHANGE_RATES_API_KEY
 ```
 
-3. Server-Side Configuration (/src/api/.env)
+### 4. Server-Side Configuration (Express / Firebase Functions)
+
+The Express API initializes `dotenv` at its entry point, pointing back four levels to load the workspace root `.env` file:
+
+```bash
+// src/api/routes.ts
+import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Resolve path to root /.env from build directory
+const envPath = path.resolve(__dirname, '../../../../.env');
+dotenv.config({ path: envPath });
+```
+
+Accessing in Backend TypeScript Code:
+
+```bash
+# /src/api/src/services/EnvironmentServiceImpl
+let API_KEY = process.env.EXCHANGE_RATES_API_KEY;
+```

--- a/src/api/package-lock.json
+++ b/src/api/package-lock.json
@@ -6,10 +6,12 @@
     "": {
       "name": "functions",
       "dependencies": {
+        "dotenv": "^17.4.2",
         "firebase-admin": "^13.6.0",
         "firebase-functions": "^7.0.0"
       },
       "devDependencies": {
+        "@types/node": "^22.20.2",
         "@types/supertest": "^7.2.1",
         "@typescript-eslint/eslint-plugin": "^5.12.0",
         "@typescript-eslint/parser": "^5.12.0",
@@ -2348,12 +2350,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.2.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
-      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "version": "22.20.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.2.tgz",
+      "integrity": "sha512-xlvWf4Vs9n1PEVYwP1n4vvG07M6y8WgvJ2t0vbrWTmijsIHp1cS+uJ2kMIRdY3nHZK0nCYKrPeD171+SzF4/zw==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~8.3.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/qs": {
@@ -4413,6 +4415,18 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {
@@ -10996,9 +11010,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/src/api/package.json
+++ b/src/api/package.json
@@ -6,10 +6,12 @@
   },
   "main": "lib/index.js",
   "dependencies": {
+    "dotenv": "^17.4.2",
     "firebase-admin": "^13.6.0",
     "firebase-functions": "^7.0.0"
   },
   "devDependencies": {
+    "@types/node": "^22.20.2",
     "@types/supertest": "^7.2.1",
     "@typescript-eslint/eslint-plugin": "^5.12.0",
     "@typescript-eslint/parser": "^5.12.0",

--- a/src/api/src/routes/routes.ts
+++ b/src/api/src/routes/routes.ts
@@ -1,13 +1,3 @@
-import dotenv from "dotenv";
-import path from "path";
-import {fileURLToPath} from "url";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const envPath = path.resolve(__dirname, "../../../../.env");
-dotenv.config({ path: envPath });
-
 import express, {type Express} from "express";
 import ExchangeRatesServiceImpl from "../services/ExchangeRates/ExchangeRatesServiceImpl.js";
 import {catchAll} from "../middleware/ErrorHandling.js";

--- a/src/api/src/routes/routes.ts
+++ b/src/api/src/routes/routes.ts
@@ -1,3 +1,13 @@
+import dotenv from "dotenv";
+import path from "path";
+import {fileURLToPath} from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const envPath = path.resolve(__dirname, "../../../../.env");
+dotenv.config({ path: envPath });
+
 import express, {type Express} from "express";
 import ExchangeRatesServiceImpl from "../services/ExchangeRates/ExchangeRatesServiceImpl.js";
 import {catchAll} from "../middleware/ErrorHandling.js";

--- a/src/api/src/services/Environment/EnvironmentServiceImpl.ts
+++ b/src/api/src/services/Environment/EnvironmentServiceImpl.ts
@@ -1,7 +1,18 @@
+import dotenv from "dotenv";
+import path from "path";
+import { fileURLToPath } from "url";
+
 /**
  * The environment service implementation.
  */
 export default class EnvironmentServiceImpl {
+  constructor() {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = path.dirname(__filename);
+
+    const envPath = path.resolve(__dirname, "../../../../../.env");
+    dotenv.config({ path: envPath });
+  }
 
   getExchangeRatesURL(): string {
     let API_KEY = process.env.EXCHANGE_RATES_API_KEY;

--- a/src/api/src/services/Environment/EnvironmentServiceImpl.ts
+++ b/src/api/src/services/Environment/EnvironmentServiceImpl.ts
@@ -4,7 +4,7 @@
 export default class EnvironmentServiceImpl {
 
   getExchangeRatesURL(): string {
-    let API_KEY = process.env.VITE_EXCHANGE_RATES_API_KEY;
+    let API_KEY = process.env.EXCHANGE_RATES_API_KEY;
     let BASE_URL = "https://api.exchangeratesapi.io/v1/latest";
     
     return `${BASE_URL}?access_key=${API_KEY}`;

--- a/src/web/vite.config.ts
+++ b/src/web/vite.config.ts
@@ -1,7 +1,9 @@
 import { defineConfig } from 'vite';
+import path from 'path';
 
 // Production build configuration for Firebase Hosting
 export default defineConfig({
+  envDir: path.resolve(__dirname, '../../'),
   server: {
     allowedHosts: ['.internal.jabaridash.com'],
     host: true, 


### PR DESCRIPTION
closes #162 


Notes : The fetch call is working today, so from what I understand the reason it didn't work yesterday could be that mock data was stored in local storage yesterday atfer the first fetch (that probably return an error because the API Key was missing) and blocked all new network calls since data are stored for 24 hours. Now that 24 hours have passed, the function areDataOutdated finally returned true, triggering the if block and firing the fetch() call, that is now able to find the file where the API Key is stored. 

New issue to create :  Implement environment variable validation service

The API key is now also accessible on the server side (see commit [53c5cde](https://github.com/Laurianne-M/convertor/pull/166/commits/53c5cde39b86c4b84603cc5897c7ae94d877df54)):
<img width="2265" height="1019" alt="Screen Shot 2026-09-09 at 4 59 32 PM" src="https://github.com/user-attachments/assets/991d6484-08a8-4f15-94e9-1fdf8d5e378f" />

